### PR TITLE
Revert "fix: use the updated initialization function in delegator"

### DIFF
--- a/contracts/Governance/GovernorBravoDelegate.sol
+++ b/contracts/Governance/GovernorBravoDelegate.sol
@@ -70,7 +70,7 @@ import "./GovernorBravoInterfaces.sol";
  * The delegation of votes happens through the `XVSVault` contract by calling the `delegate` or `delegateBySig` functions. These same functions can revert
  * vote delegation by calling the same function with a value of `0`.
  */
-contract GovernorBravoDelegate is GovernorBravoDelegateInterface, GovernorBravoDelegateStorageV2, GovernorBravoEvents {
+contract GovernorBravoDelegate is GovernorBravoDelegateStorageV2, GovernorBravoEvents {
     /// @notice The name of this contract
     string public constant name = "Venus Governor Bravo";
 

--- a/contracts/Governance/GovernorBravoDelegator.sol
+++ b/contracts/Governance/GovernorBravoDelegator.sol
@@ -10,11 +10,13 @@ import "./GovernorBravoInterfaces.sol";
  */
 contract GovernorBravoDelegator is GovernorBravoDelegatorStorage, GovernorBravoEvents {
     constructor(
+        address timelock_,
         address xvsVault_,
         address admin_,
         address implementation_,
-        GovernorBravoDelegateInterface.ProposalConfig[] memory proposalConfigs_,
-        address[] memory timelocks_,
+        uint votingPeriod_,
+        uint votingDelay_,
+        uint proposalThreshold_,
         address guardian_
     ) public {
         // Admin set to msg.sender for initialization
@@ -22,11 +24,13 @@ contract GovernorBravoDelegator is GovernorBravoDelegatorStorage, GovernorBravoE
 
         delegateTo(
             implementation_,
-            abi.encodeWithSelector(
-                GovernorBravoDelegateInterface(implementation_).initialize.selector,
+            abi.encodeWithSignature(
+                "initialize(address,address,uint256,uint256,uint256,address)",
+                timelock_,
                 xvsVault_,
-                proposalConfigs_,
-                timelocks_,
+                votingPeriod_,
+                votingDelay_,
+                proposalThreshold_,
                 guardian_
             )
         );

--- a/contracts/Governance/GovernorBravoInterfaces.sol
+++ b/contracts/Governance/GovernorBravoInterfaces.sol
@@ -190,19 +190,6 @@ contract GovernorBravoDelegateStorageV2 is GovernorBravoDelegateStorageV1 {
         CRITICAL
     }
 
-    /// @notice mapping containing configuration for each proposal type
-    mapping(uint => GovernorBravoDelegateInterface.ProposalConfig) public proposalConfigs;
-
-    /// @notice mapping containing Timelock addresses for each proposal type
-    mapping(uint => TimelockInterface) public proposalTimelocks;
-}
-
-/**
- * @title TimelockInterface
- * @author Venus
- * @notice Interface implemented by the GovernorBravoDelegate contract.
- */
-interface GovernorBravoDelegateInterface {
     struct ProposalConfig {
         /// @notice The delay before voting on a proposal may take place, once proposed, in blocks
         uint256 votingDelay;
@@ -212,12 +199,11 @@ interface GovernorBravoDelegateInterface {
         uint256 proposalThreshold;
     }
 
-    function initialize(
-        address xvsVault_,
-        ProposalConfig[] calldata proposalConfigs_,
-        TimelockInterface[] calldata timelocks,
-        address guardian_
-    ) external;
+    /// @notice mapping containing configuration for each proposal type
+    mapping(uint => ProposalConfig) public proposalConfigs;
+
+    /// @notice mapping containing Timelock addresses for each proposal type
+    mapping(uint => TimelockInterface) public proposalTimelocks;
 }
 
 /**

--- a/contracts/legacy/GovenorBravoV1.sol
+++ b/contracts/legacy/GovenorBravoV1.sol
@@ -1,0 +1,97 @@
+pragma solidity ^0.5.16;
+pragma experimental ABIEncoderV2;
+
+import "./GovernorBravoInterfaces.sol";
+
+/**
+ * @title GovernorBravoDelegator
+ * @author Venus
+ * @notice The `GovernorBravoDelegator` contract.
+ */
+contract GovernorBravoDelegatorV1 is GovernorBravoDelegatorStorage, GovernorBravoEventsV1 {
+    constructor(
+        address timelock_,
+        address xvsVault_,
+        address admin_,
+        address implementation_,
+        uint votingPeriod_,
+        uint votingDelay_,
+        uint proposalThreshold_,
+        address guardian_
+    ) public {
+        // Admin set to msg.sender for initialization
+        admin = msg.sender;
+
+        delegateTo(
+            implementation_,
+            abi.encodeWithSignature(
+                "initialize(address,address,uint256,uint256,uint256,address)",
+                timelock_,
+                xvsVault_,
+                votingPeriod_,
+                votingDelay_,
+                proposalThreshold_,
+                guardian_
+            )
+        );
+
+        _setImplementation(implementation_);
+
+        admin = admin_;
+    }
+
+    /**
+     * @notice Called by the admin to update the implementation of the delegator
+     * @param implementation_ The address of the new implementation for delegation
+     */
+    function _setImplementation(address implementation_) public {
+        require(msg.sender == admin, "GovernorBravoDelegator::_setImplementation: admin only");
+        require(
+            implementation_ != address(0),
+            "GovernorBravoDelegator::_setImplementation: invalid implementation address"
+        );
+
+        address oldImplementation = implementation;
+        implementation = implementation_;
+
+        emit NewImplementation(oldImplementation, implementation);
+    }
+
+    /**
+     * @notice Internal method to delegate execution to another contract
+     * @dev It returns to the external caller whatever the implementation returns or forwards reverts
+     * @param callee The contract to delegatecall
+     * @param data The raw data to delegatecall
+     */
+    function delegateTo(address callee, bytes memory data) internal {
+        (bool success, bytes memory returnData) = callee.delegatecall(data);
+        assembly {
+            if eq(success, 0) {
+                revert(add(returnData, 0x20), returndatasize)
+            }
+        }
+    }
+
+    /**
+     * @dev Delegates execution to an implementation contract.
+     * It returns to the external caller whatever the implementation returns
+     * or forwards reverts.
+     */
+    function() external payable {
+        // delegate all other functions to current implementation
+        (bool success, ) = implementation.delegatecall(msg.data);
+
+        assembly {
+            let free_mem_ptr := mload(0x40)
+            returndatacopy(free_mem_ptr, 0, returndatasize)
+
+            switch success
+            case 0 {
+                revert(free_mem_ptr, returndatasize)
+            }
+            default {
+                return(free_mem_ptr, returndatasize)
+            }
+        }
+    }
+}


### PR DESCRIPTION
This reverts commit a2f0bc852854c701e9f48086a7eaeddde208a306.

## Description

We can leave the constructor as it originally was deployed. To deploy the updated governance the process should be followed as it was done originally 

- Deploy BravoDelegator and BravoDelegateV1
- Deploy BravoDelegateV2 and point the proxy to it