### PR TITLE
[VEN-2178]: add Timelock compatible with solidity 8

### DIFF
--- a/contracts/Governance/TimelockV8.sol
+++ b/contracts/Governance/TimelockV8.sol
@@ -1,0 +1,229 @@
+// SPDX-License-Identifier: BSD-3-Clause
+pragma solidity 0.8.13;
+import { ensureNonzeroAddress } from "@venusprotocol/solidity-utilities/contracts/validators.sol";
+
+/**
+ * @title TimelockV8
+ * @author Venus
+ * @notice The Timelock contract using solidity V8.
+ * This contract also differs from the original timelock because it has a virtual function to get minimum delays
+ * and allow test deployments to override the value.
+ */
+contract TimelockV8 {
+    /// @notice Event emitted when a new admin is accepted
+    event NewAdmin(address indexed newAdmin);
+
+    /// @notice Event emitted when a new admin is proposed
+    event NewPendingAdmin(address indexed newPendingAdmin);
+
+    /// @notice Event emitted when a new admin is proposed
+    event NewDelay(uint256 indexed newDelay);
+
+    /// @notice Event emitted when a proposal transaction has been cancelled
+    event CancelTransaction(
+        bytes32 indexed txHash,
+        address indexed target,
+        uint256 value,
+        string signature,
+        bytes data,
+        uint256 eta
+    );
+
+    /// @notice Event emitted when a proposal transaction has been executed
+    event ExecuteTransaction(
+        bytes32 indexed txHash,
+        address indexed target,
+        uint256 value,
+        string signature,
+        bytes data,
+        uint256 eta
+    );
+
+    /// @notice Event emitted when a proposal transaction has been queued
+    event QueueTransaction(
+        bytes32 indexed txHash,
+        address indexed target,
+        uint256 value,
+        string signature,
+        bytes data,
+        uint256 eta
+    );
+
+    /// @notice Required period to execute a proposal transaction
+    uint256 private constant DEFAULT_GRACE_PERIOD = 14 days;
+
+    /// @notice Minimum amount of time a proposal transaction must be queued
+    uint256 private constant DEFAULT_MINIMUM_DELAY = 1 hours;
+
+    /// @notice Maximum amount of time a proposal transaction must be queued
+    uint256 private constant DEFAULT_MAXIMUM_DELAY = 30 days;
+
+    /// @notice Timelock admin authorized to queue and execute transactions
+    address public admin;
+
+    /// @notice Account proposed as the next admin
+    address public pendingAdmin;
+
+    /// @notice Period for a proposal transaction to be queued
+    uint256 public delay;
+
+    /// @notice Mapping of queued transactions
+    mapping(bytes32 => bool) public queuedTransactions;
+
+    constructor(address admin_, uint256 delay_) {
+        require(delay_ >= getMinimumDelay(), "Timelock::constructor: Delay must exceed minimum delay.");
+        require(delay_ <= getMaximumDelay(), "Timelock::setDelay: Delay must not exceed maximum delay.");
+        ensureNonzeroAddress(admin_);
+
+        admin = admin_;
+        delay = delay_;
+    }
+
+    fallback() external payable {}
+
+    /**
+     * @notice Setter for the transaction queue delay
+     * @param delay_ The new delay period for the transaction queue
+     */
+    function setDelay(uint256 delay_) public {
+        require(msg.sender == address(this), "Timelock::setDelay: Call must come from Timelock.");
+        require(delay_ >= getMinimumDelay(), "Timelock::setDelay: Delay must exceed minimum delay.");
+        require(delay_ <= getMaximumDelay(), "Timelock::setDelay: Delay must not exceed maximum delay.");
+        delay = delay_;
+
+        emit NewDelay(delay);
+    }
+
+    function getGracePeriod() public view virtual returns (uint256) {
+        return DEFAULT_GRACE_PERIOD;
+    }
+
+    function getMinimumDelay() public view virtual returns (uint256) {
+        return DEFAULT_MINIMUM_DELAY;
+    }
+
+    function getMaximumDelay() public view virtual returns (uint256) {
+        return DEFAULT_MAXIMUM_DELAY;
+    }
+
+    /**
+     * @notice Method for accepting a proposed admin
+     */
+    function acceptAdmin() public {
+        require(msg.sender == pendingAdmin, "Timelock::acceptAdmin: Call must come from pendingAdmin.");
+        admin = msg.sender;
+        pendingAdmin = address(0);
+
+        emit NewAdmin(admin);
+    }
+
+    /**
+     * @notice Method to propose a new admin authorized to call timelock functions. This should be the Governor Contract
+     * @param pendingAdmin_ Address of the proposed admin
+     */
+    function setPendingAdmin(address pendingAdmin_) public {
+        require(msg.sender == address(this), "Timelock::setPendingAdmin: Call must come from Timelock.");
+        ensureNonzeroAddress(pendingAdmin_);
+        pendingAdmin = pendingAdmin_;
+
+        emit NewPendingAdmin(pendingAdmin);
+    }
+
+    /**
+     * @notice Called for each action when queuing a proposal
+     * @param target Address of the contract with the method to be called
+     * @param value Native token amount sent with the transaction
+     * @param signature Ssignature of the function to be called
+     * @param data Arguments to be passed to the function when called
+     * @param eta Timestamp after which the transaction can be executed
+     * @return Hash of the queued transaction
+     */
+    function queueTransaction(
+        address target,
+        uint256 value,
+        string memory signature,
+        bytes memory data,
+        uint256 eta
+    ) public returns (bytes32) {
+        require(msg.sender == admin, "Timelock::queueTransaction: Call must come from admin.");
+        require(
+            eta >= getBlockTimestamp() + delay,
+            "Timelock::queueTransaction: Estimated execution block must satisfy delay."
+        );
+
+        bytes32 txHash = keccak256(abi.encode(target, value, signature, data, eta));
+        queuedTransactions[txHash] = true;
+
+        emit QueueTransaction(txHash, target, value, signature, data, eta);
+        return txHash;
+    }
+
+    /**
+     * @notice Called to cancel a queued transaction
+     * @param target Address of the contract with the method to be called
+     * @param value Native token amount sent with the transaction
+     * @param signature Ssignature of the function to be called
+     * @param data Arguments to be passed to the function when called
+     * @param eta Timestamp after which the transaction can be executed
+     */
+    function cancelTransaction(
+        address target,
+        uint256 value,
+        string memory signature,
+        bytes memory data,
+        uint256 eta
+    ) public {
+        require(msg.sender == admin, "Timelock::cancelTransaction: Call must come from admin.");
+
+        bytes32 txHash = keccak256(abi.encode(target, value, signature, data, eta));
+        queuedTransactions[txHash] = false;
+
+        emit CancelTransaction(txHash, target, value, signature, data, eta);
+    }
+
+    /**
+     * @notice Called to execute a queued transaction
+     * @param target Address of the contract with the method to be called
+     * @param value Native token amount sent with the transaction
+     * @param signature Ssignature of the function to be called
+     * @param data Arguments to be passed to the function when called
+     * @param eta Timestamp after which the transaction can be executed
+     */
+    function executeTransaction(
+        address target,
+        uint256 value,
+        string memory signature,
+        bytes memory data,
+        uint256 eta
+    ) public payable returns (bytes memory) {
+        require(msg.sender == admin, "Timelock::executeTransaction: Call must come from admin.");
+
+        bytes32 txHash = keccak256(abi.encode(target, value, signature, data, eta));
+        require(queuedTransactions[txHash], "Timelock::executeTransaction: Transaction hasn't been queued.");
+        require(getBlockTimestamp() >= eta, "Timelock::executeTransaction: Transaction hasn't surpassed time lock.");
+        require(getBlockTimestamp() <= eta + getGracePeriod(), "Timelock::executeTransaction: Transaction is stale.");
+
+        queuedTransactions[txHash] = false;
+
+        bytes memory callData;
+
+        if (bytes(signature).length == 0) {
+            callData = data;
+        } else {
+            callData = abi.encodePacked(bytes4(keccak256(bytes(signature))), data);
+        }
+
+        // solium-disable-next-line security/no-call-value
+        (bool success, bytes memory returnData) = target.call{ value: value }(callData);
+        require(success, "Timelock::executeTransaction: Transaction execution reverted.");
+
+        emit ExecuteTransaction(txHash, target, value, signature, data, eta);
+
+        return returnData;
+    }
+
+    function getBlockTimestamp() internal view returns (uint256) {
+        // solium-disable-next-line security/no-block-members
+        return block.timestamp;
+    }
+}

--- a/contracts/test/TestTimelockV8.sol
+++ b/contracts/test/TestTimelockV8.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: BSD-3-Clause
+pragma solidity 0.8.13;
+import { TimelockV8 } from "../Governance/TimelockV8.sol";
+
+contract TestTimelockV8 is TimelockV8 {
+    constructor(address admin_, uint256 delay_) public TimelockV8(admin_, delay_) {}
+
+    function getGracePeriod() public view override returns (uint256) {
+        return 1;
+    }
+
+    function getMinimumDelay() public view override returns (uint256) {
+        return 1;
+    }
+
+    function getMaximumDelay() public view override returns (uint256) {
+        return 1 hours;
+    }
+}

--- a/helpers/utils.ts
+++ b/helpers/utils.ts
@@ -1,4 +1,5 @@
 import BigNumber from "bignumber.js";
+import { ethers, network } from "hardhat";
 
 BigNumber.config({
   FORMAT: {
@@ -19,4 +20,28 @@ export const convertToUnit = (amount: string | number, decimals: number) => {
 
 export const convertToBigInt = (amount: string | number, decimals: number) => {
   return BigInt(convertToUnit(amount, decimals));
+};
+
+export const fundAccount = async (address: string) => {
+  const [deployer] = await ethers.getSigners();
+  await deployer.sendTransaction({
+    to: address,
+    value: ethers.utils.parseEther("1.0"),
+  });
+};
+
+export const impersonateSigner = async (address: string) => {
+  await network.provider.request({
+    method: "hardhat_impersonateAccount",
+    params: [address],
+  });
+  const signer = await ethers.getSigner(address);
+  return signer;
+};
+
+export const releaseImpersonation = async (address: string) => {
+  await network.provider.request({
+    method: "hardhat_stopImpersonatingAccount",
+    params: [address],
+  });
 };

--- a/package.json
+++ b/package.json
@@ -38,6 +38,9 @@
     "docgen": "hardhat docgen",
     "prepare": "husky install"
   },
+  "dependencies": {
+    "@venusprotocol/solidity-utilities": "^1.1.0"
+  },
   "devDependencies": {
     "@commitlint/cli": "^17.4.4",
     "@commitlint/config-conventional": "^17.4.4",

--- a/tests/Governance/GovernanceBravo/timelock.ts
+++ b/tests/Governance/GovernanceBravo/timelock.ts
@@ -1,0 +1,94 @@
+import chai from "chai";
+import { ethers } from "hardhat";
+
+import { fundAccount, impersonateSigner, releaseImpersonation } from "../../../helpers/utils";
+
+const { expect } = chai;
+
+describe("TimelockV8 Tests", () => {
+  let deployer;
+  let timelockFactory;
+  let timelock;
+  let testTimelockFactory;
+  let testTimelock;
+
+  before(async () => {
+    [deployer] = await ethers.getSigners();
+    timelockFactory = await ethers.getContractFactory("TimelockV8");
+    timelock = await timelockFactory.deploy(deployer.address, 4000);
+
+    testTimelockFactory = await ethers.getContractFactory("TestTimelockV8");
+    testTimelock = await testTimelockFactory.deploy(deployer.address, 10);
+  });
+
+  it("Production timelock returns constant values", async () => {
+    expect(await timelock.getGracePeriod()).to.equal("1209600");
+    expect(await timelock.getMinimumDelay()).to.equal("3600");
+    expect(await timelock.getMaximumDelay()).to.equal("2592000");
+  });
+
+  it("Production timelock requires setting appropriate delay", async () => {
+    await fundAccount(timelock.address);
+
+    const timelockSigner = await impersonateSigner(timelock.address);
+
+    await expect(timelock.connect(timelockSigner).setDelay("5000")).to.emit(timelock, "NewDelay").withArgs("5000");
+
+    await expect(timelock.connect(timelockSigner).setDelay("1000")).to.be.revertedWith(
+      "Timelock::setDelay: Delay must exceed minimum delay.",
+    );
+
+    await expect(timelock.connect(timelockSigner).setDelay("5000000")).to.be.revertedWith(
+      "Timelock::setDelay: Delay must not exceed maximum delay.",
+    );
+
+    await releaseImpersonation(timelock.address);
+  });
+
+  it("Production timelock does not allow a null address", async () => {
+    await expect(timelockFactory.deploy("0x0000000000000000000000000000000000000000", 4000)).to.be.rejectedWith(
+      "ZeroAddressNotAllowed()",
+    );
+
+    await fundAccount(timelock.address);
+    const timelockSigner = await impersonateSigner(timelock.address);
+
+    await expect(
+      timelock.connect(timelockSigner).setPendingAdmin("0x0000000000000000000000000000000000000000"),
+    ).to.be.rejectedWith("ZeroAddressNotAllowed()");
+
+    await releaseImpersonation(timelock.address);
+  });
+
+  it("Test Timelock returns 1 for constants", async () => {
+    expect(await testTimelock.getGracePeriod()).to.equal("1");
+    expect(await testTimelock.getMinimumDelay()).to.equal("1");
+    expect(await testTimelock.getMaximumDelay()).to.equal("3600");
+  });
+
+  it("Test Timelock allows setting low delay", async () => {
+    await fundAccount(testTimelock.address);
+
+    const timelockSigner = await impersonateSigner(testTimelock.address);
+
+    expect(await testTimelock.connect(timelockSigner).setDelay("10"))
+      .to.emit(testTimelock, "NewDelay")
+      .withArgs("10");
+
+    await releaseImpersonation(testTimelock.address);
+  });
+
+  it("Test timelock does not allow a null address", async () => {
+    await expect(testTimelockFactory.deploy("0x0000000000000000000000000000000000000000", 10)).to.be.rejectedWith(
+      "ZeroAddressNotAllowed()",
+    );
+
+    const timelockSigner = await impersonateSigner(testTimelock.address);
+
+    await expect(
+      testTimelock.connect(timelockSigner).setPendingAdmin("0x0000000000000000000000000000000000000000"),
+    ).to.be.rejectedWith("ZeroAddressNotAllowed()");
+
+    await releaseImpersonation(testTimelock.address);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2756,6 +2756,7 @@ __metadata:
     "@types/node": ^18.16.3
     "@typescript-eslint/eslint-plugin": ^5.44.0
     "@typescript-eslint/parser": ^5.44.0
+    "@venusprotocol/solidity-utilities": ^1.1.0
     "@venusprotocol/venus-protocol": 0.4.1
     bignumber.js: ^9.1.1
     chai: ^4.3.7
@@ -2792,6 +2793,13 @@ __metadata:
     typescript: ^4.9.3
   languageName: unknown
   linkType: soft
+
+"@venusprotocol/solidity-utilities@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@venusprotocol/solidity-utilities@npm:1.1.0"
+  checksum: 3b17ec451cd0ba5aaea76686c7bef35757fb158709214be094f73ebd0d643c79817159f7aa162cc694e1a5ee1f02b20e26211a65929113b985827959aae99fa7
+  languageName: node
+  linkType: hard
 
 "@venusprotocol/venus-protocol@npm:0.4.1":
   version: 0.4.1


### PR DESCRIPTION
Adds virtual getters for min and max values so they can be customized in testnet and for testing

## Description

Adds a Timelock contract that is compatible with Solidity v8 and has overridable getters for deployment in test environments ( testnets, hardhat)
