### PR TITLE
refactor: fetch contract from deployments instead of importing deprecated address file

### DIFF
--- a/helpers/deploy/deploymentUtils.ts
+++ b/helpers/deploy/deploymentUtils.ts
@@ -1,18 +1,18 @@
-import bscMainnetDeployments from "@venusprotocol/venus-protocol/networks/mainnet.json";
-import bscTestnetDeployments from "@venusprotocol/venus-protocol/networks/testnet.json";
-import { getNamedAccounts } from "hardhat";
+import { ethers, getNamedAccounts } from "hardhat";
 
 import { SUPPORTED_NETWORKS } from "./constants";
 
 export const getAcmAdminAccount = async (network: SUPPORTED_NETWORKS): Promise<string> => {
   const { deployer } = await getNamedAccounts();
-  return {
-    bsctestnet: bscTestnetDeployments.Contracts.Timelock, // NORMAL TIMELOCK
-    bscmainnet: bscMainnetDeployments.Contracts.Timelock, // NORMAL TIMELOCK
-    sepolia: "0x94fa6078b6b8a26f0b6edffbe6501b22a10470fb", // SEPOLIA MULTISIG
-    ethereum: "0x285960C5B22fD66A736C7136967A3eB15e93CC67", // ETHEREUM MULTISIG
-    hardhat: deployer,
-  }[network];
+  if (network === "hardhat") {
+    return deployer;
+  } else if (network === "sepolia") {
+    return "0x94fa6078b6b8a26f0b6edffbe6501b22a10470fb"; // SEPOLIA MULTISIG
+  } else if (network === "ethereum") {
+    return "0x285960C5B22fD66A736C7136967A3eB15e93CC67"; // ETHEREUM MULTISIG
+  }
+  const normalTimelock = await ethers.getContract("NormalTimeLock");
+  return normalTimelock.address;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function


### PR DESCRIPTION
## Description

This refactors out the package dependency which will break if packages consuming this one are using a more recent version of `venus-protocol`