### PR TITLE
fix: maintain original interface

### DIFF
--- a/contracts/Governance/TimelockV8.sol
+++ b/contracts/Governance/TimelockV8.sol
@@ -71,8 +71,8 @@ contract TimelockV8 {
     mapping(bytes32 => bool) public queuedTransactions;
 
     constructor(address admin_, uint256 delay_) {
-        require(delay_ >= getMinimumDelay(), "Timelock::constructor: Delay must exceed minimum delay.");
-        require(delay_ <= getMaximumDelay(), "Timelock::setDelay: Delay must not exceed maximum delay.");
+        require(delay_ >= MINIMUM_DELAY(), "Timelock::constructor: Delay must exceed minimum delay.");
+        require(delay_ <= MAXIMUM_DELAY(), "Timelock::setDelay: Delay must not exceed maximum delay.");
         ensureNonzeroAddress(admin_);
 
         admin = admin_;
@@ -87,22 +87,22 @@ contract TimelockV8 {
      */
     function setDelay(uint256 delay_) public {
         require(msg.sender == address(this), "Timelock::setDelay: Call must come from Timelock.");
-        require(delay_ >= getMinimumDelay(), "Timelock::setDelay: Delay must exceed minimum delay.");
-        require(delay_ <= getMaximumDelay(), "Timelock::setDelay: Delay must not exceed maximum delay.");
+        require(delay_ >= MINIMUM_DELAY(), "Timelock::setDelay: Delay must exceed minimum delay.");
+        require(delay_ <= MAXIMUM_DELAY(), "Timelock::setDelay: Delay must not exceed maximum delay.");
         delay = delay_;
 
         emit NewDelay(delay);
     }
 
-    function getGracePeriod() public view virtual returns (uint256) {
+    function GRACE_PERIOD() public view virtual returns (uint256) {
         return DEFAULT_GRACE_PERIOD;
     }
 
-    function getMinimumDelay() public view virtual returns (uint256) {
+    function MINIMUM_DELAY() public view virtual returns (uint256) {
         return DEFAULT_MINIMUM_DELAY;
     }
 
-    function getMaximumDelay() public view virtual returns (uint256) {
+    function MAXIMUM_DELAY() public view virtual returns (uint256) {
         return DEFAULT_MAXIMUM_DELAY;
     }
 
@@ -201,7 +201,7 @@ contract TimelockV8 {
         bytes32 txHash = keccak256(abi.encode(target, value, signature, data, eta));
         require(queuedTransactions[txHash], "Timelock::executeTransaction: Transaction hasn't been queued.");
         require(getBlockTimestamp() >= eta, "Timelock::executeTransaction: Transaction hasn't surpassed time lock.");
-        require(getBlockTimestamp() <= eta + getGracePeriod(), "Timelock::executeTransaction: Transaction is stale.");
+        require(getBlockTimestamp() <= eta + GRACE_PERIOD(), "Timelock::executeTransaction: Transaction is stale.");
 
         queuedTransactions[txHash] = false;
 

--- a/contracts/test/TestTimelockV8.sol
+++ b/contracts/test/TestTimelockV8.sol
@@ -5,15 +5,15 @@ import { TimelockV8 } from "../Governance/TimelockV8.sol";
 contract TestTimelockV8 is TimelockV8 {
     constructor(address admin_, uint256 delay_) public TimelockV8(admin_, delay_) {}
 
-    function getGracePeriod() public view override returns (uint256) {
+    function GRACE_PERIOD() public view override returns (uint256) {
         return 1;
     }
 
-    function getMinimumDelay() public view override returns (uint256) {
+    function MINIMUM_DELAY() public view override returns (uint256) {
         return 1;
     }
 
-    function getMaximumDelay() public view override returns (uint256) {
+    function MAXIMUM_DELAY() public view override returns (uint256) {
         return 1 hours;
     }
 }

--- a/tests/Governance/GovernanceBravo/timelock.ts
+++ b/tests/Governance/GovernanceBravo/timelock.ts
@@ -22,9 +22,9 @@ describe("TimelockV8 Tests", () => {
   });
 
   it("Production timelock returns constant values", async () => {
-    expect(await timelock.getGracePeriod()).to.equal("1209600");
-    expect(await timelock.getMinimumDelay()).to.equal("3600");
-    expect(await timelock.getMaximumDelay()).to.equal("2592000");
+    expect(await timelock.GRACE_PERIOD()).to.equal("1209600");
+    expect(await timelock.MINIMUM_DELAY()).to.equal("3600");
+    expect(await timelock.MAXIMUM_DELAY()).to.equal("2592000");
   });
 
   it("Production timelock requires setting appropriate delay", async () => {
@@ -61,9 +61,9 @@ describe("TimelockV8 Tests", () => {
   });
 
   it("Test Timelock returns 1 for constants", async () => {
-    expect(await testTimelock.getGracePeriod()).to.equal("1");
-    expect(await testTimelock.getMinimumDelay()).to.equal("1");
-    expect(await testTimelock.getMaximumDelay()).to.equal("3600");
+    expect(await testTimelock.GRACE_PERIOD()).to.equal("1");
+    expect(await testTimelock.MINIMUM_DELAY()).to.equal("1");
+    expect(await testTimelock.MAXIMUM_DELAY()).to.equal("3600");
   });
 
   it("Test Timelock allows setting low delay", async () => {


### PR DESCRIPTION
## Description

When using the test timelock in tests, there are breaking calls because the interface changed. This keeps the original interface so the new test timelock can be set in legacy governors
