### PR TITLE
feat!: migrate to 0.8.25

### DIFF
--- a/contracts/Governance/AccessControlManager.sol
+++ b/contracts/Governance/AccessControlManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity 0.8.25;
 import "@openzeppelin/contracts/access/AccessControl.sol";
 import "./IAccessControlManagerV8.sol";
 

--- a/contracts/Governance/AccessControlledV8.sol
+++ b/contracts/Governance/AccessControlledV8.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity 0.8.25;
 
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";

--- a/contracts/Governance/IAccessControlManagerV8.sol
+++ b/contracts/Governance/IAccessControlManagerV8.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity ^0.8.25;
 
 import "@openzeppelin/contracts/access/IAccessControl.sol";
 

--- a/contracts/Governance/TimelockV8.sol
+++ b/contracts/Governance/TimelockV8.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity 0.8.25;
 import { ensureNonzeroAddress } from "@venusprotocol/solidity-utilities/contracts/validators.sol";
 
 /**

--- a/contracts/test/MockAccessTest.sol
+++ b/contracts/test/MockAccessTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity 0.8.25;
 
 import "../Governance/AccessControlledV8.sol";
 

--- a/contracts/test/TestTimelockV8.sol
+++ b/contracts/test/TestTimelockV8.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity 0.8.25;
 import { TimelockV8 } from "../Governance/TimelockV8.sol";
 
 contract TestTimelockV8 is TimelockV8 {

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -56,7 +56,7 @@ const config: HardhatUserConfig = {
         },
       },
       {
-        version: "0.8.13",
+        version: "0.8.25",
         settings: {
           optimizer: {
             enabled: true,

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "prepare": "husky install"
   },
   "dependencies": {
-    "@venusprotocol/solidity-utilities": "^1.1.0",
+    "@venusprotocol/solidity-utilities": "2.0.0",
     "hardhat-deploy-ethers": "^0.3.0-beta.13",
     "module-alias": "^2.2.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2756,7 +2756,7 @@ __metadata:
     "@types/node": ^18.16.3
     "@typescript-eslint/eslint-plugin": ^5.44.0
     "@typescript-eslint/parser": ^5.44.0
-    "@venusprotocol/solidity-utilities": ^1.1.0
+    "@venusprotocol/solidity-utilities": 2.0.0
     "@venusprotocol/venus-protocol": 0.4.1
     bignumber.js: ^9.1.1
     chai: ^4.3.7
@@ -2796,10 +2796,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@venusprotocol/solidity-utilities@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "@venusprotocol/solidity-utilities@npm:1.1.0"
-  checksum: 3b17ec451cd0ba5aaea76686c7bef35757fb158709214be094f73ebd0d643c79817159f7aa162cc694e1a5ee1f02b20e26211a65929113b985827959aae99fa7
+"@venusprotocol/solidity-utilities@npm:2.0.0":
+  version: 2.0.0
+  resolution: "@venusprotocol/solidity-utilities@npm:2.0.0"
+  checksum: 87a2ce2fd1d702bc04c4e98d675b904176c7f2489476e8da586d1782b48faae92aa4f2ba894737773d189ba72a6b274f1464cf2e0308e62758303d0adde749e6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR updates the pragma to:

* `^0.8.25` for interfaces, constants, etc.
* `0.8.25` for anything that contains code

Before merging, the dependencies have to be updated after https://github.com/VenusProtocol/solidity-utilities/pull/18 is merged.