### PR TITLE
chore: include typechain in package

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "author": "",
   "files": [
     "artifacts",
+    "typechain",
     "dist",
     "deploy",
     "deployments",


### PR DESCRIPTION
## Description

Include typechain in package. This will be required when merging the crosschain governance deployment scripts
