### PR TITLE
fix: compile hardhat so typechain can exist when compiling typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "scripts": {
     "compile": "hardhat compile",
     "test": "hardhat test",
-    "build": "rm -rf dist && tsc --declaration && hardhat compile",
+    "build": "rm -rf dist && hardhat compile && tsc --declaration",
     "publish:dist": "yarn build && cd dist && yarn publish --access public",
     "lint": "yarn lint:ts && yarn lint:sol && yarn prettier:check",
     "lint:ts": "eslint --ignore-path ./.eslintignore --ext .js,.ts .",


### PR DESCRIPTION
## Description

Because the typechain is now used in build scripts it needs to exist before we build typescript. Running hardhat compile first ensures this
