### PR TITLE
chore: publish slim package

### DIFF
--- a/.github/prepare_slim_package.sh
+++ b/.github/prepare_slim_package.sh
@@ -1,0 +1,16 @@
+# Create a slim folder with the minium content we want, and remove unneeded files
+mkdir slim && cp -r artifacts* package.json README.md deployments slim && cd slim
+find deployments -mindepth 1 -depth -not -name "*_addresses.json*" -exec rm -r "{}" +
+find artifacts -mindepth 1 -depth -not -regex "artifacts/contracts.*" -exec rm -r "{}" +
+find artifacts-zk -mindepth 1 -depth -not -regex "artifacts-zk/contracts.*" -exec rm -r "{}" +
+find artifacts -mindepth 1 -depth -regex "artifacts/.*dbg\.json" -exec rm -r "{}" +
+
+# Add "-slim" to the version in the npm package, keeping the tag "-dev" if it exists
+jq '.version |= sub("^(?<core>[0-9]+\\.[0-9]+\\.[0-9]+)"; "\(.core)-slim")' package.json > package.tmp.json && mv package.tmp.json package.json 
+
+# Remove the "prepare" script because husky won't work for this slim version
+jq 'del(.scripts.prepare)' package.json > package.tmp.json && mv package.tmp.json package.json
+
+# Empty devDependencies and dependencies
+jq '.dependencies = {}' package.json > package.tmp.json && mv package.tmp.json package.json
+jq '.devDependencies = {}' package.json > package.tmp.json && mv package.tmp.json package.json

--- a/.github/publish_slim_package.sh
+++ b/.github/publish_slim_package.sh
@@ -1,0 +1,10 @@
+# Set npm authentication
+echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
+
+cd slim
+
+# Extract to PRE_RELEASE_TAG the tag in the version field of the package json, or the empty string if it doesn't exist
+PRE_RELEASE_TAG=$(jq -r '.version | if test("-") then capture("^[0-9]+\\.[0-9]+\\.[0-9]+(?<tag>-[a-zA-Z-]+)") | .tag else "" end' package.json)
+
+# Publish the package to a custom tag for slim versions
+npm publish --access public --tag slim$PRE_RELEASE_TAG

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -36,3 +36,11 @@ jobs:
           GIT_COMMITTER_NAME: Venus Tools
           GIT_COMMITTER_EMAIL: tools@venus.io
         run: yarn semantic-release
+
+      - name: Prepare slim package
+        run: bash .github/prepare_slim_package.sh
+
+      - name: Publish slim package
+        run: bash .github/publish_slim_package.sh
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Description

Add CD scripts to publish a slimmer version of the `governance-contracts` package containing ABIs and addresses only
