### PR TITLE
chore: publish slim package

### DIFF
--- a/.github/prepare_slim_package.sh
+++ b/.github/prepare_slim_package.sh
@@ -8,8 +8,9 @@ find artifacts -mindepth 1 -depth -regex "artifacts/.*dbg\.json" -exec rm -r "{}
 # Add "-slim" to the version in the npm package, keeping the tag "-dev" if it exists
 jq '.version |= sub("^(?<core>[0-9]+\\.[0-9]+\\.[0-9]+)"; "\(.core)-slim")' package.json > package.tmp.json && mv package.tmp.json package.json 
 
-# Remove the "prepare" script because husky won't work for this slim version
+# Remove the "prepare" and "postinstall" scripts, they won't work for this slim version
 jq 'del(.scripts.prepare)' package.json > package.tmp.json && mv package.tmp.json package.json
+jq 'del(.scripts.postinstall)' package.json > package.tmp.json && mv package.tmp.json package.json
 
 # Empty devDependencies and dependencies
 jq '.dependencies = {}' package.json > package.tmp.json && mv package.tmp.json package.json

--- a/.github/publish_slim_package.sh
+++ b/.github/publish_slim_package.sh
@@ -4,7 +4,7 @@ echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
 cd slim
 
 # Extract to PRE_RELEASE_TAG the tag in the version field of the package json, or the empty string if it doesn't exist
-PRE_RELEASE_TAG=$(jq -r '.version | if test("-") then capture("^[0-9]+\\.[0-9]+\\.[0-9]+(?<tag>-[a-zA-Z-]+)") | .tag else "" end' package.json)
+PRE_RELEASE_TAG=$(jq -r '.version | if test("-") then capture("^[0-9]+\\.[0-9]+\\.[0-9]+-(?<tag>[a-zA-Z-]+)") | .tag else "" end' package.json)
 
 # Publish the package to a custom tag for slim versions
-npm publish --access public --tag slim$PRE_RELEASE_TAG
+npm publish --provenance --access public --tag $PRE_RELEASE_TAG

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -9,6 +9,8 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@venusprotocol/governance-contracts",
   "description": "",
+  "repository": "git@github.com:VenusProtocol/governance-contracts.git",
   "version": "2.14.0-dev.1",
   "author": "",
   "files": [


### PR DESCRIPTION
## Description

Add CD scripts to publish a slimmer version of the `token-bridge` package containing ABIs and addresses only
